### PR TITLE
Fix some typos, mainly the CVE number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reset inetpub
 
-This script restores the `%SYSTEMDRIVE%\inetpub` folder and its default security permissions, which are necessary as a mitigation for [CVE-2025-2120](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-2120) following the [KB5055523](https://support.microsoft.com/en-gb/topic/april-8-2025-kb5055523-os-build-26100-3775-277a9d11-6ebf-410c-99f7-8c61957461eb) Windows update.
+This script restores the `%SYSTEMDRIVE%\inetpub` folder and its default security permissions, which are necessary as a mitigation for [CVE-2025-21204](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-21204) following the [KB5055523](https://support.microsoft.com/en-gb/topic/april-8-2025-kb5055523-os-build-26100-3775-277a9d11-6ebf-410c-99f7-8c61957461eb) Windows update.
 
 It's intended for users who may have deleted this folder before understanding its security purpose and wish to restore it without needing to enable/disable IIS features.
 

--- a/Reset.ps1
+++ b/Reset.ps1
@@ -3,7 +3,7 @@
 Restores the %SYSTEMDRIVE%\inetpub directory and resets its default security permissions and ownership.
 
 .DESCRIPTION
-This script addresses the creation of the %SYSTEMDRIVE%\inetpub directory introduced by Windows update KB5055523 as a mitigation for CVE-2025-2120.
+This script addresses the creation of the %SYSTEMDRIVE%\inetpub directory introduced by Windows update KB5055523 as a mitigation for CVE-2025-21204.
 It facilitates the restoration of this directory and its required permissions for users who may have previously deleted it, without necessitating the enablement or disablement of IIS features.
 
 The script performs the following actions:
@@ -42,7 +42,7 @@ Warning:     This script modifies file system permissions and ownership on the %
 .LINK
 GitHub Repository: https://github.com/mmotti/Reset-inetpub
 KB5055523: https://support.microsoft.com/en-gb/topic/april-8-2025-kb5055523-os-build-26100-3775-277a9d11-6ebf-410c-99f7-8c61957461eb
-CVE-2025-2120: https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-2120
+CVE-2025-21204: https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-21204
 #>
 #Requires -RunAsAdministrator
 
@@ -131,7 +131,7 @@ try {
             Write-Status -Status OK -Message "Directory created." -Indent 1
         }
         catch {
-            throw "Unable to to create directory: $targetPath"
+            throw "Unable to create directory: $targetPath"
         }
     # Directory exists.
     } else {


### PR DESCRIPTION
Hi there, thanks for the handy script!

It took me a minute to figure out why the CVE link didn't work; typos happen to the best of us, I guess.

For giggles, I grokked through both the README and the script for typos, in strings and identifiers. This PR is intended to be exhaustive, though I wouldn't be surprised if I overlooked something.